### PR TITLE
fix: fix iframe hijack

### DIFF
--- a/src/components/frame/FrameConnector.tsx
+++ b/src/components/frame/FrameConnector.tsx
@@ -101,6 +101,7 @@ export const FrameConnector: FunctionComponent<FrameConnectorProps | LegacyFrame
       src={source}
       style={style}
       className={className}
+      sandbox="allow-scripts allow-same-origin"
     />
   );
 };


### PR DESCRIPTION
Fixed the problem where child frame can hijack host URL to malicious site which could look like opencerts or tradetrust showing valid content. 

Attempts to do so now, will trigger the following errors:

![image](https://user-images.githubusercontent.com/7406870/86566995-35b44a00-bf9d-11ea-91d4-c14e8a8972ac.png)
