### PR TITLE
feat: penpal v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ This component will establish a connection with a host embedding the application
 - `attachmentToComponent`: a function that map attachments to component depending on the attachment type. Currently the library exposes 2 functions:
   - `noAttachmentRenderer`: which uses `UnsupportedRenderer` (basically it's doing nothing)
   - `fullAttachmentRenderer`: which uses all the supported attachment type by the library (see the function).
-This property default to `noAttachmentRenderer`, to avoid bundles growing huge unnecessarily.
+    This property default to `noAttachmentRenderer`, to avoid bundles growing huge unnecessarily.
 
 `FramedDocumentRenderer` handle all the logic around the communication with the hosted application and the renderer:
 
@@ -190,8 +190,8 @@ Each configured `Template` will be provided the following properties, when rende
 - `rawDocument`: (optional) Open Attestation document
 - `handleObfuscation`: (mandatory) A function to call to handle obfuscation in the document. The value provided must follow path property as handlded by [lodash#get](https://lodash.com/docs/4.17.15#get)
 
-
 ## Development
+
 - `npm run storybook`: to start storybook, create stories and visualize the different component
 - `npm run test`: to run tests
 - `npm run lint`: to run lint
@@ -199,3 +199,7 @@ Each configured `Template` will be provided the following properties, when rende
 - `npm run example:renderer`: to run the example build with the library to develop a decentralized renderer. Don't forget to update the example if you update this library.
 
 We also provided a [github template](https://github.com/Open-Attestation/decentralized-renderer-react-template) to build your own decentralized-renderer based on this library
+
+## Penpal
+
+There is compatibility [issues](https://github.com/Aaronius/penpal/issues/52) between penpal version ^5 and ^4. In the event that penpal version ^4 must be used, use this version [4.1.1](https://github.com/Aaronius/penpal/releases/tag/v4.1.1)

--- a/example/application/app.tsx
+++ b/example/application/app.tsx
@@ -10,7 +10,7 @@ export const App: React.FunctionComponent = (): React.ReactElement => {
       documents={[
         { name: "OpenCerts (v2)", document: rawOpencerts, frameSource: "http://localhost:9000" },
         { name: "Driver License (V3)", document: driverLicense, frameSource: "http://localhost:9000" },
-        { name: "Legacy (Penpal V4)", document: { id: "legacy" }, frameSource: "http://localhost:8080" }
+        { name: "Legacy (Penpal V4)", document: { id: "legacy" }, frameSource: "http://localhost:8080" },
       ]}
     />
   );

--- a/example/application/app.tsx
+++ b/example/application/app.tsx
@@ -4,12 +4,16 @@ import { driverLicense } from "./fixtures/v3/driverLicense";
 import React from "react";
 import { AppContainer } from "./container";
 
-ReactDOM.render(
-  <AppContainer
-    documents={[
-      { name: "OpenCerts (v2)", document: rawOpencerts },
-      { name: "Driver License (V3)", document: driverLicense },
-    ]}
-  />,
-  document.getElementById("root")
-);
+export const App: React.FunctionComponent = (): React.ReactElement => {
+  return (
+    <AppContainer
+      documents={[
+        { name: "OpenCerts (v2)", document: rawOpencerts, frameSource: "http://localhost:9000" },
+        { name: "Driver License (V3)", document: driverLicense, frameSource: "http://localhost:9000" },
+        { name: "Legacy (Penpal V4)", document: { id: "legacy" }, frameSource: "http://localhost:8080" }
+      ]}
+    />
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/example/application/container.tsx
+++ b/example/application/container.tsx
@@ -3,11 +3,16 @@ import { FrameActions, FrameConnector, HostActionsHandler } from "../../src";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
+type Document = {
+  name: string;
+  document: any;
+  frameSource: string;
+};
 interface AppProps {
-  documents: {
-    name: string;
-    document: any;
-  }[];
+  documents: Document[];
+}
+interface ViewerProps {
+  document: Document;
 }
 
 const TemplatesContainer = styled.div``;
@@ -29,18 +34,13 @@ const ActionsContainer = styled.div`
     cursor: pointer;
     border: 0;
   }
-  button: hover {
+  button:hover {
     background-color: #2b6cb0;
   }
 `;
 
-const FrameContainer = styled.div`
-  display: flex;
-`;
 const DocumentsContainer = styled.div`
   width: 300px;
-  min-width: 300px;
-  max-width: 300px;
   padding: 0.5rem;
 
   .document {
@@ -57,11 +57,10 @@ const DocumentsContainer = styled.div`
   }
 `;
 
-export const AppContainer: React.FunctionComponent<AppProps> = ({ documents }): React.ReactElement => {
+const Viewer: React.FunctionComponent<ViewerProps> = ({ document }): React.ReactElement => {
   const [toFrame, setToFrame] = useState<HostActionsHandler>();
   const [height, setHeight] = useState(50);
   const [templates, setTemplates] = useState<{ id: string; label: string }[]>([]);
-  const [document, setDocument] = useState<{ name: string; document: any }>();
   const [selectedTemplate, setSelectedTemplate] = useState<string>("");
   const fn = useCallback((toFrame: HostActionsHandler) => {
     // wrap into a function otherwise toFrame function will be executed
@@ -110,7 +109,11 @@ export const AppContainer: React.FunctionComponent<AppProps> = ({ documents }): 
   }, [selectedTemplate, toFrame]);
 
   return (
-    <div>
+    <div
+      css={css`
+        flex: 1 0 auto;
+      `}
+    >
       <ActionsContainer>
         <button
           onClick={() => {
@@ -124,25 +127,7 @@ export const AppContainer: React.FunctionComponent<AppProps> = ({ documents }): 
           Print
         </button>
       </ActionsContainer>
-      <FrameContainer>
-        <DocumentsContainer>
-          <div
-            css={css`
-              text-align: center;
-              font-weight: bold;
-            `}
-          >
-            Documents
-          </div>
-          {documents.length === 0 && <div>Please configure the application and provide at least one document</div>}
-          {documents.map((d, index) => {
-            return (
-              <div key={index} className={`document ${document === d ? "active" : ""}`} onClick={() => setDocument(d)}>
-                {d.name}
-              </div>
-            );
-          })}
-        </DocumentsContainer>
+      <div>
         {!document && (
           <div
             css={css`
@@ -223,7 +208,7 @@ export const AppContainer: React.FunctionComponent<AppProps> = ({ documents }): 
             `}
           >
             <FrameConnector
-              source="http://localhost:9000"
+              source={document.frameSource}
               dispatch={fromFrame}
               onConnected={fn}
               css={css`
@@ -236,7 +221,32 @@ export const AppContainer: React.FunctionComponent<AppProps> = ({ documents }): 
             />
           </div>
         </div>
-      </FrameContainer>
+      </div>
+    </div>
+  );
+};
+
+export const AppContainer: React.FunctionComponent<AppProps> = ({ documents }): React.ReactElement => {
+  const [document, setDocument] = useState<Document>();
+
+  return (
+    <div
+      css={css`
+        display: flex;
+      `}
+    >
+      <DocumentsContainer>
+        <h4>Documents</h4>
+        {documents.length === 0 && <div>Please configure the application and provide at least one document</div>}
+        {documents.map((d, index) => {
+          return (
+            <div key={index} className={`document ${document === d ? "active" : ""}`} onClick={() => setDocument(d)}>
+              {d.name}
+            </div>
+          );
+        })}
+      </DocumentsContainer>
+      {document && <Viewer key={document.frameSource} document={document} />}
     </div>
   );
 };

--- a/example/application/index.html
+++ b/example/application/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <title>Custom decentralized renderer</title>
+    <title>Custom application</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/example/application/webpack.config.js
+++ b/example/application/webpack.config.js
@@ -2,7 +2,6 @@
 const path = require("path");
 
 module.exports = {
-  // ...webpackConfig,
   mode: process.env.NODE_ENV ?? "development",
   entry: path.join(__dirname, "./app.tsx"),
   externals: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -19208,7 +19208,12 @@
       "integrity": "sha512-xGDUhnCYPfHy+unMXCLCJtlpZaaZ17Ew3WIL0tnSgKFUZXHAPD49GO9xScyszSsQMoutNDgRb+rfBXIaX/lJbw=="
     },
     "penpal": {
-      "version": "4.1.1",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/penpal/-/penpal-5.3.0.tgz",
+      "integrity": "sha512-ezGckenx66j3RShl4nZiswjgDxyoDaJJ9tLBp46UvVxlA9MlIPF6hWfuppw1AzaDKgUULU1i44QFOuI4SXY/mg=="
+    },
+    "penpal-v4": {
+      "version": "npm:penpal@4.1.1",
       "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
       "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@govtechsg/open-attestation": "^5.2.2",
     "crypto-browserify": "^3.12.0",
     "debug": "^4.3.1",
-    "penpal": "^4.1.1",
+    "penpal-v4": "npm:penpal@^4.1.1",
+    "penpal": "^5.3.0",
     "react-pdf": "^5.2.0",
     "stream-browserify": "^3.0.0",
     "typesafe-actions": "^5.1.0"

--- a/src/components/frame/useFrame.ts
+++ b/src/components/frame/useFrame.ts
@@ -1,6 +1,5 @@
 import { RefObject, useEffect, useState } from "react";
 import { connectToParent, connectToChild } from "penpal";
-import connectToParentV4 from "penpal-v4/lib/connectToParent";
 import connectToChildV4 from "penpal-v4/lib/connectToChild";
 import { FrameActionsHandler, LegacyFrameActions } from "./frame.actions";
 import { HostActionsHandler, LegacyHostActions } from "./host.actions";

--- a/src/components/frame/useFrame.ts
+++ b/src/components/frame/useFrame.ts
@@ -1,10 +1,6 @@
 import { RefObject, useEffect, useState } from "react";
 import { connectToParent, connectToChild } from "penpal";
-// eslint-disable-next-line
-// @ts-ignore
 import connectToParentV4 from "penpal-v4/lib/connectToParent";
-// eslint-disable-next-line
-// @ts-ignore
 import connectToChildV4 from "penpal-v4/lib/connectToChild";
 import { FrameActionsHandler, LegacyFrameActions } from "./frame.actions";
 import { HostActionsHandler, LegacyHostActions } from "./host.actions";

--- a/src/components/frame/useFrame.ts
+++ b/src/components/frame/useFrame.ts
@@ -13,8 +13,8 @@ type Status = "DISCONNECTED" | "CONNECTING" | "CONNECTED";
 interface UseParentFrameProps {
   dispatch: HostActionsHandler;
 }
-export const useParentFrame = function({
-  dispatch
+export const useParentFrame = function ({
+  dispatch,
 }: UseParentFrameProps): [boolean, { dispatch: FrameActionsHandler }] {
   const [parentFrameConnection, setParentFrameConnection] = useState<any>();
   const [status, setStatus] = useState<Status>("DISCONNECTED");
@@ -23,20 +23,20 @@ export const useParentFrame = function({
     if (inIframe() && status === "DISCONNECTED") {
       const parentV5 = connectToParent({
         methods: {
-          dispatch: dispatch
+          dispatch: dispatch,
         },
-        timeout: 5000 // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+        timeout: 5000, // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
       }).promise;
 
       setStatus("CONNECTING");
 
       parentV5
-        .then(parentConnection => {
+        .then((parentConnection) => {
           trace("connectToParent success: ", parentConnection);
           setParentFrameConnection(parentConnection);
           setStatus("CONNECTED");
         })
-        .catch(err => {
+        .catch((err) => {
           trace("connectToParent failed: ", err);
           setStatus("DISCONNECTED");
         });
@@ -50,7 +50,7 @@ interface UseChildrenFrameProps {
   methods: LegacyFrameActions;
   iframe: RefObject<HTMLIFrameElement>;
 }
-export const useChildFrame = function(
+export const useChildFrame = function (
   props: UseChildrenFrameProps
 ): [boolean, { dispatch?: HostActionsHandler } & Partial<LegacyHostActions>] {
   const [childFrameConnection, setChildFrameConnection] = useState<any>();
@@ -61,30 +61,30 @@ export const useChildFrame = function(
       const childV5 = connectToChild({
         methods: {
           dispatch: props.dispatch,
-          ...props.methods
+          ...props.methods,
         },
         iframe: props.iframe.current,
-        timeout: 5000 // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+        timeout: 5000, // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
       }).promise;
 
       const childV4 = connectToChildV4({
         methods: {
           dispatch: props.dispatch,
-          ...props.methods
+          ...props.methods,
         },
         iframe: props.iframe.current,
-        timeout: 5000 // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+        timeout: 5000, // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
       }).promise;
 
       setStatus("CONNECTING");
 
       Promise.any([childV5, childV4])
-        .then(childConnection => {
+        .then((childConnection) => {
           trace("connectToChild success: ", childConnection);
           setChildFrameConnection(childConnection);
           setStatus("CONNECTED");
         })
-        .catch(err => {
+        .catch((err) => {
           trace("connectToChild failed: ", err);
           setStatus("DISCONNECTED");
         });

--- a/src/components/frame/useFrame.ts
+++ b/src/components/frame/useFrame.ts
@@ -7,6 +7,7 @@ import { inIframe } from "../../utils";
 import { getLogger } from "../../logger";
 
 const { trace } = getLogger("useFrame");
+const TIMEOUT = 9000;
 
 type Status = "DISCONNECTED" | "CONNECTING" | "CONNECTED";
 
@@ -25,7 +26,7 @@ export const useParentFrame = function ({
         methods: {
           dispatch: dispatch,
         },
-        timeout: 5000, // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+        timeout: TIMEOUT, // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
       }).promise;
 
       setStatus("CONNECTING");
@@ -64,7 +65,7 @@ export const useChildFrame = function (
           ...props.methods,
         },
         iframe: props.iframe.current,
-        timeout: 5000, // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+        timeout: TIMEOUT, // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
       }).promise;
 
       const childV4 = connectToChildV4({
@@ -73,7 +74,7 @@ export const useChildFrame = function (
           ...props.methods,
         },
         iframe: props.iframe.current,
-        timeout: 5000, // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+        timeout: TIMEOUT, // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
       }).promise;
 
       setStatus("CONNECTING");

--- a/src/components/frame/useFrame.ts
+++ b/src/components/frame/useFrame.ts
@@ -29,16 +29,9 @@ export const useParentFrame = function({
         timeout: 5000 // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
       }).promise;
 
-      const parentV4 = connectToParentV4({
-        methods: {
-          dispatch: dispatch
-        },
-        timeout: 5000 // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
-      }).promise;
-
       setStatus("CONNECTING");
 
-      Promise.any([parentV5, parentV4])
+      parentV5
         .then(parentConnection => {
           trace("connectToParent success: ", parentConnection);
           setParentFrameConnection(parentConnection);

--- a/src/components/frame/useFrame.ts
+++ b/src/components/frame/useFrame.ts
@@ -7,7 +7,7 @@ import { inIframe } from "../../utils";
 import { getLogger } from "../../logger";
 
 const { trace } = getLogger("useFrame");
-const TIMEOUT = 9000;
+const TIMEOUT = 30000;
 
 type Status = "DISCONNECTED" | "CONNECTING" | "CONNECTED";
 

--- a/src/components/frame/useFrame.ts
+++ b/src/components/frame/useFrame.ts
@@ -1,35 +1,57 @@
 import { RefObject, useEffect, useState } from "react";
-import connectToParent from "penpal/lib/connectToParent";
-import connectToChild from "penpal/lib/connectToChild";
+import { connectToParent, connectToChild } from "penpal";
+// eslint-disable-next-line
+// @ts-ignore
+import connectToParentV4 from "penpal-v4/lib/connectToParent";
+// eslint-disable-next-line
+// @ts-ignore
+import connectToChildV4 from "penpal-v4/lib/connectToChild";
 import { FrameActionsHandler, LegacyFrameActions } from "./frame.actions";
 import { HostActionsHandler, LegacyHostActions } from "./host.actions";
 import { inIframe } from "../../utils";
+import { getLogger } from "../../logger";
+
+const { trace } = getLogger("useFrame");
 
 type Status = "DISCONNECTED" | "CONNECTING" | "CONNECTED";
 
 interface UseParentFrameProps {
   dispatch: HostActionsHandler;
 }
-export const useParentFrame = function ({
-  dispatch,
+export const useParentFrame = function({
+  dispatch
 }: UseParentFrameProps): [boolean, { dispatch: FrameActionsHandler }] {
   const [parentFrameConnection, setParentFrameConnection] = useState<any>();
   const [status, setStatus] = useState<Status>("DISCONNECTED");
 
   useEffect(() => {
-    const run = async (): Promise<void> => {
-      setParentFrameConnection(
-        await connectToParent({
-          methods: {
-            dispatch: dispatch,
-          },
-        }).promise
-      );
-      setStatus("CONNECTED");
-    };
     if (inIframe() && status === "DISCONNECTED") {
+      const parentV5 = connectToParent({
+        methods: {
+          dispatch: dispatch
+        },
+        timeout: 5000 // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+      }).promise;
+
+      const parentV4 = connectToParentV4({
+        methods: {
+          dispatch: dispatch
+        },
+        timeout: 5000 // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+      }).promise;
+
       setStatus("CONNECTING");
-      run();
+
+      Promise.any([parentV5, parentV4])
+        .then(parentConnection => {
+          trace("connectToParent success: ", parentConnection);
+          setParentFrameConnection(parentConnection);
+          setStatus("CONNECTED");
+        })
+        .catch(err => {
+          trace("connectToParent failed: ", err);
+          setStatus("DISCONNECTED");
+        });
     }
   }, [status, dispatch]);
   return [status === "CONNECTED", parentFrameConnection];
@@ -40,29 +62,45 @@ interface UseChildrenFrameProps {
   methods: LegacyFrameActions;
   iframe: RefObject<HTMLIFrameElement>;
 }
-export const useChildFrame = function (
+export const useChildFrame = function(
   props: UseChildrenFrameProps
 ): [boolean, { dispatch?: HostActionsHandler } & Partial<LegacyHostActions>] {
-  const [parentFrameConnection, setParentFrameConnection] = useState<any>();
+  const [childFrameConnection, setChildFrameConnection] = useState<any>();
   const [status, setStatus] = useState<Status>("DISCONNECTED");
 
   useEffect(() => {
-    const run = async (): Promise<void> => {
-      setParentFrameConnection(
-        await connectToChild({
-          methods: {
-            dispatch: props.dispatch,
-            ...props.methods,
-          },
-          iframe: props.iframe.current,
-        }).promise
-      );
-      setStatus("CONNECTED");
-    };
     if (props.iframe.current && status === "DISCONNECTED") {
+      const childV5 = connectToChild({
+        methods: {
+          dispatch: props.dispatch,
+          ...props.methods
+        },
+        iframe: props.iframe.current,
+        timeout: 5000 // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+      }).promise;
+
+      const childV4 = connectToChildV4({
+        methods: {
+          dispatch: props.dispatch,
+          ...props.methods
+        },
+        iframe: props.iframe.current,
+        timeout: 5000 // this will ensure connection to promise reject, when connection versions not match. otherwise it will be stucked in promise pending
+      }).promise;
+
       setStatus("CONNECTING");
-      run();
+
+      Promise.any([childV5, childV4])
+        .then(childConnection => {
+          trace("connectToChild success: ", childConnection);
+          setChildFrameConnection(childConnection);
+          setStatus("CONNECTED");
+        })
+        .catch(err => {
+          trace("connectToChild failed: ", err);
+          setStatus("DISCONNECTED");
+        });
     }
   }, [status, props]);
-  return [status === "CONNECTED", parentFrameConnection];
+  return [status === "CONNECTED", childFrameConnection];
 };

--- a/src/types/penpal.d.ts
+++ b/src/types/penpal.d.ts
@@ -1,22 +1,24 @@
 /* eslint-disable */
 // https://github.com/Aaronius/penpal/releases/tag/v4.0.0 check TypeScript Declarations
-declare module "penpal/lib/connectToParent" {
+declare module "penpal-v4/lib/connectToParent" {
   interface ConnectToParentOptions {
     methods: {
       [key: string]: Function;
     };
+    timeout: number;
   }
   interface ConnectToParentReturn {
     promise: Promise<{ [key: string]: Function }>;
   }
   export = (options: ConnectToParentOptions): ConnectToParentReturn => {};
 }
-declare module "penpal/lib/connectToChild" {
+declare module "penpal-v4/lib/connectToChild" {
   interface ConnectToChildOptions {
     methods: {
       [key: string]: Function;
     };
     iframe: HTMLIFrameElement | null;
+    timeout: number;
   }
   interface ConnectToChildReturn {
     promise: Promise<{ [key: string]: Function }>;


### PR DESCRIPTION
### bg context
- need to upgrade to penpal v5
- if there is a mismatch of parent child connection versions, promise will not resolve and always be pending

### attempted solution
- ~~try connect v5 connect first. if timeout, try v4 connect instead (for older template renderers out there)~~
- promise.any v5 and v4 connections, first to resolved will connect. otherwise timeout to reject connection

![Screenshot 2021-03-02 at 2 42 39 PM](https://user-images.githubusercontent.com/4774314/109609016-b5fb7100-7b65-11eb-9bbf-0d16eadff975.png)
