### PR TITLE
chore: fix build bug caused by include array in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "sourceMap": true,
     "types": ["jest",  "@emotion/react"]
   },
-  "include": ["src", "example"]
+  "include": ["src"]
 }


### PR DESCRIPTION
`"include": ["src", "example"]` 

The `example `caused the extra folders to be created during build