### PR TITLE
refactor: discrete display results + svg load error handling

### DIFF
--- a/example/application/container.tsx
+++ b/example/application/container.tsx
@@ -231,6 +231,7 @@ const Viewer: React.FunctionComponent<ViewerProps> = ({ document }): React.React
                 onResult={(r) => {
                   console.log(r);
                 }}
+                loadingComponent={<div>Loading...</div>}
               />
             ) : (
               <FrameConnector

--- a/example/application/container.tsx
+++ b/example/application/container.tsx
@@ -225,7 +225,13 @@ const Viewer: React.FunctionComponent<ViewerProps> = ({ document }): React.React
             `}
           >
             {isSvg ? (
-              <__unsafe__not__for__production__v2__SvgRenderer document={document.document} ref={svgRef} />
+              <__unsafe__not__for__production__v2__SvgRenderer
+                document={document.document}
+                ref={svgRef}
+                onResult={(r) => {
+                  console.log(r);
+                }}
+              />
             ) : (
               <FrameConnector
                 source={document.frameSource}

--- a/src/components/renderer/SvgRenderer.test.tsx
+++ b/src/components/renderer/SvgRenderer.test.tsx
@@ -158,13 +158,12 @@ describe("svgRenderer component", () => {
 
     fireEvent.error(getByAltText("Svg image of the verified document"));
 
-    const defaultTemplate = await findByTestId("default-template", undefined, {
-      timeout: 5000,
-    });
+    const defaultTemplate = await findByTestId("default-template");
     expect(defaultTemplate.textContent).toContain("The resolved SVG is malformedThe resolved SVG is malformed");
     expect(queryByTestId("Svg image of the verified document")).not.toBeInTheDocument();
     expect(mockHandleResult).toHaveBeenCalledWith({
       status: "INVALID_SVG_ERROR",
+      svg: "",
     });
   });
 });

--- a/src/components/renderer/SvgRenderer.test.tsx
+++ b/src/components/renderer/SvgRenderer.test.tsx
@@ -162,8 +162,8 @@ describe("svgRenderer component", () => {
     expect(defaultTemplate.textContent).toContain("The resolved SVG is malformedThe resolved SVG is malformed");
     expect(queryByTestId("Svg image of the verified document")).not.toBeInTheDocument();
     expect(mockHandleResult).toHaveBeenCalledWith({
-      status: "INVALID_SVG_ERROR",
-      svg: "",
+      status: "MALFORMED_SVG_ERROR",
+      svgDataUri: "data:image/svg+xml,",
     });
   });
 });

--- a/src/components/renderer/SvgRenderer.test.tsx
+++ b/src/components/renderer/SvgRenderer.test.tsx
@@ -2,7 +2,7 @@
 // Disable the spyOn check due to known issues with mocking fetch in jsDom env
 // https://stackoverflow.com/questions/74945569/cannot-access-built-in-node-js-fetch-function-from-jest-tests
 import { render } from "@testing-library/react";
-import { DisplayResult, SvgRenderer } from "./SvgRenderer";
+import { SvgRenderer } from "./SvgRenderer";
 import fs from "fs";
 import { Blob } from "buffer";
 import React from "react";
@@ -114,7 +114,7 @@ describe("svgRenderer component", () => {
     const defaultTemplate = await findByTestId("default-template");
     expect(defaultTemplate.textContent).toContain("The remote content for this document has been modified");
     expect(defaultTemplate.textContent).toContain(`URL: “http://mockbucket.com/static/svg_test.svg”`);
-    expect(mockHandleResult).toHaveBeenCalledWith(DisplayResult.DIGEST_ERROR, undefined);
+    expect(mockHandleResult).toHaveBeenCalledWith({ status: "DIGEST_ERROR" });
   });
 
   it("should render default template when document.RenderMethod is undefined", async () => {
@@ -141,10 +141,10 @@ describe("svgRenderer component", () => {
     const defaultTemplate = await findByTestId("default-template");
     expect(defaultTemplate.textContent).toContain("This document might be having loading issues");
     expect(defaultTemplate.textContent).toContain(`URL: “http://mockbucket.com/static/svg_test.svg”`);
-    expect(mockHandleResult).toHaveBeenCalledWith(
-      DisplayResult.CONNECTION_ERROR,
-      new Error("Failed to fetch remote SVG")
-    );
+    expect(mockHandleResult).toHaveBeenCalledWith({
+      error: new Error("Failed to fetch remote SVG"),
+      status: "FETCH_SVG_ERROR",
+    });
   });
 });
 /* eslint-enable jest/prefer-spy-on */

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -32,11 +32,7 @@ export interface v4OpenAttestationDocument {
   renderMethod?: RenderMethod[];
 }
 
-export type InternalDisplayResult =
-  | {
-      status: "OK";
-      svg: string;
-    }
+type InternalDisplayResult =
   | {
       status: "DEFAULT";
     }
@@ -145,7 +141,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
 
             if (!digestMultibaseInDoc) {
               handleResult({
-                status: "OK",
+                status: "PENDING_IMG_LOAD",
                 svg: svgText,
               });
             } else {
@@ -155,7 +151,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
                 const recomputedDigestMultibase = "z" + bs58.encode(shaDigest); // manually prefix with 'z' as per https://w3c-ccg.github.io/multibase/#mh-registry
                 if (recomputedDigestMultibase === digestMultibaseInDoc) {
                   handleResult({
-                    status: "OK",
+                    status: "PENDING_IMG_LOAD",
                     svg: svgText,
                   });
                 } else {

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -75,6 +75,8 @@ export interface SvgRendererProps {
   // TODO: How to handle if svg fails at img? Currently it will return twice
   /** An optional callback method that returns the display result  */
   onResult?: (result: DisplayResult) => void;
+  /** An optional component to display while loading */
+  loadingComponent?: React.ReactNode;
 }
 
 const fetchSvg = async (svgInDoc: string, abortController: AbortController) => {
@@ -94,7 +96,7 @@ export const SVG_RENDERER_TYPE = "SvgRenderingTemplate2023";
  * Component that accepts a v4 document to fetch and display the first available template SVG
  */
 const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
-  ({ document, style, className, onResult }, ref) => {
+  ({ document, style, className, onResult, loadingComponent }, ref) => {
     const [toDisplay, setToDisplay] = useState<
       InternalDisplayResult | PendingImgLoadDisplayResult | ResolvedImgLoadDisplayResult | null
     >(null);
@@ -184,7 +186,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
       return document.credentialSubject ? compiledTemplate(document.credentialSubject) : compiledTemplate(document);
     };
 
-    if (!toDisplay) return <></>;
+    if (!toDisplay) return loadingComponent ? <>{loadingComponent}</> : <></>;
 
     const handleImgResolved = (resolvedDisplayResult: ResolvedImgLoadDisplayResult) => () => {
       setToDisplay(resolvedDisplayResult);

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -49,6 +49,7 @@ export type DisplayResult =
     }
   | {
       status: "INVALID_SVG_ERROR";
+      svg: string;
     };
 
 // this immediate loading state does not need to be exposed
@@ -217,6 +218,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
             onError={() => {
               handleResult({
                 status: "INVALID_SVG_ERROR",
+                svg: toDisplay.svg,
               });
             }}
           />

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -105,6 +105,8 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
     const isSvgUrl = urlPattern.test(svgInDoc);
 
     useEffect(() => {
+      setToDisplay(null);
+
       const handleResult = (result: InternalDisplayResult | PendingImgLoadDisplayResult) => {
         setToDisplay(result);
 

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -34,10 +34,6 @@ export interface v4OpenAttestationDocument {
 
 export type DisplayResult =
   | {
-      status: "PENDING_IMG_LOAD";
-      svg: string;
-    }
-  | {
       status: "OK";
       svg: string;
     }
@@ -53,6 +49,14 @@ export type DisplayResult =
     }
   | {
       status: "INVALID_SVG_ERROR";
+    };
+
+// this immediate loading state does not need to be exposed
+type InternalDisplayResult =
+  | DisplayResult
+  | {
+      status: "PENDING_IMG_LOAD";
+      svg: string;
     };
 
 export interface SvgRendererProps {
@@ -88,7 +92,7 @@ export const SVG_RENDERER_TYPE = "SvgRenderingTemplate2023";
  */
 const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
   ({ document, style, className, onResult }, ref) => {
-    const [toDisplay, setToDisplay] = useState<DisplayResult | null>(null);
+    const [toDisplay, setToDisplay] = useState<InternalDisplayResult | null>(null);
 
     const renderMethod = document.renderMethod?.find((method) => method.type === SVG_RENDERER_TYPE);
     const svgInDoc = renderMethod?.id ?? "";
@@ -107,7 +111,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
       if (!isSvgUrl) {
         // Case 1: SVG is embedded in the doc, can directly display
         handleResult({
-          status: "OK",
+          status: "PENDING_IMG_LOAD",
           svg: svgInDoc,
         });
       } else {
@@ -157,7 +161,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
       /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, [document]);
 
-    const handleResult = (result: DisplayResult) => {
+    const handleResult = (result: InternalDisplayResult) => {
       setToDisplay(result);
 
       if (onResult) {

--- a/src/components/renderer/SvgV2Adapter.tsx
+++ b/src/components/renderer/SvgV2Adapter.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from "react";
-import { DisplayResult, SvgRenderer, v4OpenAttestationDocument } from "./SvgRenderer";
+import { DisplayResult, SvgRenderer, SvgRendererProps, v4OpenAttestationDocument } from "./SvgRenderer";
 import { v2 } from "@govtechsg/open-attestation";
 
 const mapV2toV4 = (document: v2.OpenAttestationDocument): v4OpenAttestationDocument => {
@@ -22,24 +22,17 @@ const mapV2toV4 = (document: v2.OpenAttestationDocument): v4OpenAttestationDocum
   };
 };
 
-export interface __unsafe__not__for__production__v2__SvgRendererProps {
-  /** The OpenAttestation v4 document to display */
-  document: v2.OpenAttestationDocument; // TODO: Update to OpenAttestationDocument
-  /** Override the img style */
-  style?: CSSProperties;
-  /** Override the img className */
-  className?: string;
-  // TODO: How to handle if svg fails at img? Currently it will return twice
-  /** An optional callback method that returns the display result  */
-  onResult?: (result: DisplayResult) => void;
-}
+export type __unsafe__not__for__production__v2__SvgRendererProps = Omit<SvgRendererProps, "document"> & {
+  /** The OpenAttestation v2 document to display */
+  document: v2.OpenAttestationDocument;
+};
 
 const __unsafe__not__for__production__v2__SvgRenderer = React.forwardRef<
   HTMLImageElement,
   __unsafe__not__for__production__v2__SvgRendererProps
->(({ document, style, className, onResult }, ref) => {
+>(({ document, ...rest }, ref) => {
   const remappedDocument = mapV2toV4(document);
-  return <SvgRenderer document={remappedDocument} style={style} className={className} onResult={onResult} ref={ref} />;
+  return <SvgRenderer {...rest} document={remappedDocument} ref={ref} />;
 });
 
 __unsafe__not__for__production__v2__SvgRenderer.displayName = "SvgRendererAdapterComponent";

--- a/src/components/renderer/fixtures/svgRendererSamples.ts
+++ b/src/components/renderer/fixtures/svgRendererSamples.ts
@@ -165,6 +165,34 @@ export const v4WithOnlyTamperedEmbeddedSvg = {
   },
 };
 
+export const v4MalformedEmbeddedSvg = {
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://schemata.openattestation.com/com/openattestation/4.0/alpha-context.json",
+  ],
+  issuer: {
+    id: "did:ethr:0xB26B4941941C51a4885E5B7D3A1B861E54405f90",
+    type: "OpenAttestationIssuer",
+    name: "Government Technology Agency of Singapore (GovTech)",
+    // identityProof: { identityProofType: v4.IdentityProofType.DNSDid, identifier: "example.openattestation.com" },
+    identityProof: { identityProofType: v2.IdentityProofType.DNSDid, identifier: "example.openattestation.com" },
+  },
+  // credentialStatus: { type: "OpenAttestationCredentialStatus", credentialStatusType: v4.CredentialStatusType.None },
+  credentialStatus: { type: "OpenAttestationCredentialStatus", credentialStatusType: "NONE" },
+  renderMethod: [
+    {
+      id: "",
+      type: "SvgRenderingTemplate2023",
+    },
+  ],
+  credentialSubject: {
+    id: "urn:uuid:a013fb9d-bb03-4056-b696-05575eceaf42",
+    type: ["SvgExample"],
+    course: { name: "SVG Basics Workshop", fromDate: "01/01/2024", endDate: "16/01/2024" },
+    recipient: { name: "TAN CHEN CHEN" },
+  },
+};
+
 export const v2WithSvgUrlAndDigestMultibase = {
   issuers: [
     {


### PR DESCRIPTION
## Proposal
1. Combine display results, svg text and error to discriminated union see (https://basarat.gitbook.io/typescript/type-system/discriminated-unions)
2. Add a new display result: `PENDING_OK`, which is the state before the img results resolved
3. We delay the call of onResult for `PENDING_OK`, until it resolves to either `OK` or `SVG_LOAD_ERROR`