### PR TITLE
Feat/add w3c svg render method shiyu proposal

### DIFF
--- a/example/application/app.tsx
+++ b/example/application/app.tsx
@@ -2,7 +2,7 @@ import ReactDOM from "react-dom";
 import { rawOpencerts } from "./fixtures/v2/opencerts";
 import { certWithBadTemplateName, certWithNoTemplate } from "./fixtures/v2/certs-to-test-default-renderer";
 import { driverLicense } from "./fixtures/v3/driverLicense";
-import { svgEmbeddedDemoV2, svgHostedDemoV2 } from "./fixtures/v2/svgDemoV2";
+import { malformSvgDemoV2, svgEmbeddedDemoV2, svgHostedDemoV2 } from "./fixtures/v2/svgDemoV2";
 import React from "react";
 import { AppContainer } from "./container";
 
@@ -24,6 +24,7 @@ export const App: React.FunctionComponent = (): React.ReactElement => {
         { name: "Driver License (V3)", document: driverLicense, frameSource: "http://localhost:9000" },
         { name: "Legacy (Penpal V4)", document: { id: "legacy" }, frameSource: "http://localhost:8080" },
         { name: "SVG Embedded Demo (V2)", document: svgEmbeddedDemoV2, frameSource: "" },
+        { name: "Malformed SVG (V2)", document: malformSvgDemoV2, frameSource: "" },
         { name: "SVG Hosted Demo (V2)", document: svgHostedDemoV2, frameSource: "" },
       ]}
     />

--- a/example/application/container.tsx
+++ b/example/application/container.tsx
@@ -225,7 +225,14 @@ const Viewer: React.FunctionComponent<ViewerProps> = ({ document }): React.React
             `}
           >
             {isSvg ? (
-              <__unsafe__not__for__production__v2__SvgRenderer document={document.document} ref={svgRef} />
+              <__unsafe__not__for__production__v2__SvgRenderer
+                document={document.document}
+                ref={svgRef}
+                onResult={(r) => {
+                  console.log(r);
+                }}
+                loadingComponent={<div>Loading...</div>}
+              />
             ) : (
               <FrameConnector
                 source={document.frameSource}

--- a/example/application/fixtures/v2/svgDemoV2.ts
+++ b/example/application/fixtures/v2/svgDemoV2.ts
@@ -32,6 +32,34 @@ export const svgEmbeddedDemoV2 = {
   },
 };
 
+export const malformSvgDemoV2 = {
+  issuers: [
+    {
+      id: "did:ethr:0xB26B4941941C51a4885E5B7D3A1B861E54405f90",
+      name: "Government Technology Agency of Singapore (GovTech)",
+      revocation: {
+        type: v2.RevocationType.None,
+      },
+      identityProof: {
+        type: v2.IdentityProofType.DNSDid,
+        location: "example.openattestation.com",
+        key: "did:ethr:0xB26B4941941C51a4885E5B7D3A1B861E54405f90#controller",
+      },
+    },
+  ],
+  renderMethod: [
+    {
+      id: `<sv.`,
+      type: "SvgRenderingTemplate2023",
+      name: "SVG Demo",
+    },
+  ],
+  qualification: "SVG rendering",
+  recipient: {
+    name: "Yourself",
+  },
+};
+
 export const svgHostedDemoV2 = {
   issuers: [
     {

--- a/src/components/renderer/SvgRenderer.test.tsx
+++ b/src/components/renderer/SvgRenderer.test.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable jest/prefer-spy-on */
 // Disable the spyOn check due to known issues with mocking fetch in jsDom env
 // https://stackoverflow.com/questions/74945569/cannot-access-built-in-node-js-fetch-function-from-jest-tests
-import { render } from "@testing-library/react";
-import { DisplayResult, SvgRenderer } from "./SvgRenderer";
+import { fireEvent, render } from "@testing-library/react";
+import { SvgRenderer } from "./SvgRenderer";
 import fs from "fs";
 import { Blob } from "buffer";
 import React from "react";
@@ -13,6 +13,7 @@ import {
   v2WithSvgUrlAndDigestMultibase,
   v4WithOnlyTamperedEmbeddedSvg,
   v4WithNoRenderMethod,
+  v4MalformedEmbeddedSvg,
 } from "./fixtures/svgRendererSamples";
 import { __unsafe__not__for__production__v2__SvgRenderer } from "./SvgV2Adapter";
 
@@ -114,7 +115,7 @@ describe("svgRenderer component", () => {
     const defaultTemplate = await findByTestId("default-template");
     expect(defaultTemplate.textContent).toContain("The remote content for this document has been modified");
     expect(defaultTemplate.textContent).toContain(`URL: “http://mockbucket.com/static/svg_test.svg”`);
-    expect(mockHandleResult).toHaveBeenCalledWith(DisplayResult.DIGEST_ERROR, undefined);
+    expect(mockHandleResult).toHaveBeenCalledWith({ status: "DIGEST_ERROR" });
   });
 
   it("should render default template when document.RenderMethod is undefined", async () => {
@@ -141,10 +142,29 @@ describe("svgRenderer component", () => {
     const defaultTemplate = await findByTestId("default-template");
     expect(defaultTemplate.textContent).toContain("This document might be having loading issues");
     expect(defaultTemplate.textContent).toContain(`URL: “http://mockbucket.com/static/svg_test.svg”`);
-    expect(mockHandleResult).toHaveBeenCalledWith(
-      DisplayResult.CONNECTION_ERROR,
-      new Error("Failed to fetch remote SVG")
+    expect(mockHandleResult).toHaveBeenCalledWith({
+      error: new Error("Failed to fetch remote SVG"),
+      status: "FETCH_SVG_ERROR",
+    });
+  });
+
+  it("should render svg malformed template when img load event is fired", async () => {
+    const svgRef = React.createRef<HTMLImageElement>();
+    const mockHandleResult = jest.fn();
+
+    const { findByTestId, getByAltText, queryByTestId } = render(
+      <SvgRenderer document={v4MalformedEmbeddedSvg} ref={svgRef} onResult={mockHandleResult} />
     );
+
+    fireEvent.error(getByAltText("Svg image of the verified document"));
+
+    const defaultTemplate = await findByTestId("default-template");
+    expect(defaultTemplate.textContent).toContain("The resolved SVG is malformedThe resolved SVG is malformed");
+    expect(queryByTestId("Svg image of the verified document")).not.toBeInTheDocument();
+    expect(mockHandleResult).toHaveBeenCalledWith({
+      status: "MALFORMED_SVG_ERROR",
+      svgDataUri: "data:image/svg+xml,",
+    });
   });
 });
 /* eslint-enable jest/prefer-spy-on */

--- a/src/components/renderer/SvgRenderer.test.tsx
+++ b/src/components/renderer/SvgRenderer.test.tsx
@@ -148,7 +148,7 @@ describe("svgRenderer component", () => {
     });
   });
 
-  it("should render svg malformed template when img load event is fired", async () => {
+  it("should render svg svg load error template when img load event is fired", async () => {
     const svgRef = React.createRef<HTMLImageElement>();
     const mockHandleResult = jest.fn();
 
@@ -159,10 +159,10 @@ describe("svgRenderer component", () => {
     fireEvent.error(getByAltText("Svg image of the verified document"));
 
     const defaultTemplate = await findByTestId("default-template");
-    expect(defaultTemplate.textContent).toContain("The resolved SVG is malformedThe resolved SVG is malformed");
+    expect(defaultTemplate.textContent).toContain("The resolved SVG could not be loaded");
     expect(queryByTestId("Svg image of the verified document")).not.toBeInTheDocument();
     expect(mockHandleResult).toHaveBeenCalledWith({
-      status: "MALFORMED_SVG_ERROR",
+      status: "SVG_LOAD_ERROR",
       svgDataUri: "data:image/svg+xml,",
     });
   });

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -3,8 +3,7 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import bs58 from "bs58";
 import { ConnectionFailureTemplate, DefaultTemplate, NoTemplate, TamperedSvgTemplate } from "../../DefaultTemplate";
 import type { v2 } from "@govtechsg/open-attestation";
-/* eslint-disable-next-line @typescript-eslint/no-var-requires */
-const handlebars = require("handlebars");
+import handlebars from "handlebars";
 
 interface RenderMethod {
   id: string;

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -108,9 +108,6 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
 
     const renderMethod = document.renderMethod?.find((method) => method.type === SVG_RENDERER_TYPE);
     const svgInDoc = renderMethod?.id ?? "";
-    const urlPattern = /^https?:\/\/.*\.svg$/;
-    const isSvgUrl = urlPattern.test(svgInDoc);
-
     useEffect(() => {
       setToDisplay({ status: "LOADING" });
 
@@ -139,6 +136,8 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
       }
       const abortController = new AbortController();
 
+      const urlPattern = /^https?:\/\/.*\.svg$/;
+      const isSvgUrl = urlPattern.test(svgInDoc);
       if (!isSvgUrl) {
         // Case 1: SVG is embedded in the doc, can directly display
         handleValidSvgTemplate(svgInDoc);
@@ -180,7 +179,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
       return () => {
         abortController.abort();
       };
-    }, [document, onResult, isSvgUrl, renderMethod, svgInDoc]);
+    }, [document, onResult, svgInDoc, renderMethod?.digestMultibase]);
 
     const handleImgResolved = (result: ValidSvgTemplateDisplayResult) => () => {
       setToDisplay(result);

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -214,7 +214,6 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
                 : style
             }
             title="Svg Renderer Image"
-            width="100%"
             src={toDisplay.svgDataUri}
             ref={ref}
             alt="Svg image of the verified document"

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -49,7 +49,7 @@ type ValidSvgTemplateDisplayResult =
       svgDataUri: string;
     }
   | {
-      status: "MALFORMED_SVG_ERROR";
+      status: "SVG_LOAD_ERROR";
       svgDataUri: string;
     };
 
@@ -117,8 +117,9 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
       };
 
       /** we have everything we need to generate the svg data uri, but we do not know if
-       * it is malformed or not until it is loaded by the image element, hence we do not
-       * call onResult here, instead we call it in the img onLoad and onError handlers
+       * it is malformed/blocked by CORS or not until it is loaded by the image element,
+       * hence we do not call onResult here, instead we call it in the img onLoad and
+       * onError handlers
        */
       const handleValidSvgTemplate = (rawSvgTemplate: string) => {
         setToDisplay({
@@ -188,11 +189,11 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
     switch (toDisplay.status) {
       case "LOADING":
         return loadingComponent ? <>{loadingComponent}</> : null;
-      case "MALFORMED_SVG_ERROR":
+      case "SVG_LOAD_ERROR":
         return (
           <DefaultTemplate
-            title="The resolved SVG is malformed"
-            description={<>The resolved SVG is malformed. Please contact the issuer.</>}
+            title="The resolved SVG could not be loaded"
+            description={<>The resolved SVG is either blocked or malformed. Please contact the issuer.</>}
             document={document}
           />
         );
@@ -217,7 +218,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
             ref={ref}
             alt="Svg image of the verified document"
             onLoad={handleImgResolved({ status: "OK", svgDataUri: toDisplay.svgDataUri })}
-            onError={handleImgResolved({ status: "MALFORMED_SVG_ERROR", svgDataUri: toDisplay.svgDataUri })}
+            onError={handleImgResolved({ status: "SVG_LOAD_ERROR", svgDataUri: toDisplay.svgDataUri })}
           />
         );
       }

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -32,6 +32,34 @@ export interface v4OpenAttestationDocument {
   renderMethod?: RenderMethod[];
 }
 
+type InvalidSvgTemplateDisplayResult =
+  | {
+      status: "DEFAULT";
+    }
+  | {
+      status: "DIGEST_ERROR";
+    }
+  | {
+      status: "FETCH_SVG_ERROR";
+      error: Error;
+    };
+
+type ValidSvgTemplateDisplayResult =
+  | {
+      status: "OK";
+      svgDataUri: string;
+    }
+  | {
+      status: "MALFORMED_SVG_ERROR";
+      svgDataUri: string;
+    };
+
+type LoadingDisplayResult = {
+  status: "LOADING";
+};
+
+export type DisplayResult = InvalidSvgTemplateDisplayResult | ValidSvgTemplateDisplayResult;
+
 export interface SvgRendererProps {
   /** The OpenAttestation v4 document to display */
   document: v4OpenAttestationDocument; // TODO: Update to OpenAttestationDocument
@@ -42,14 +70,6 @@ export interface SvgRendererProps {
   // TODO: How to handle if svg fails at img? Currently it will return twice
   /** An optional callback method that returns the display result  */
   onResult?: (result: DisplayResult, err?: Error) => void;
-}
-
-/** Indicates the result of SVG rendering */
-export enum DisplayResult {
-  OK = "OK",
-  DEFAULT = "DEFAULT",
-  CONNECTION_ERROR = "CONNECTION_ERROR",
-  DIGEST_ERROR = "DIGEST_ERROR",
 }
 
 const fetchSvg = async (svgInDoc: string, abortController: AbortController) => {

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -67,9 +67,10 @@ export interface SvgRendererProps {
   style?: CSSProperties;
   /** Override the img className */
   className?: string;
-  // TODO: How to handle if svg fails at img? Currently it will return twice
   /** An optional callback method that returns the display result  */
   onResult?: (result: DisplayResult, err?: Error) => void;
+  /** An optional component to display while loading */
+  loadingComponent?: React.ReactNode;
 }
 
 const fetchSvg = async (svgInDoc: string, abortController: AbortController) => {
@@ -95,10 +96,9 @@ export const SVG_RENDERER_TYPE = "SvgRenderingTemplate2023";
  * Component that accepts a v4 document to fetch and display the first available template SVG
  */
 const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
-  ({ document, style, className, onResult }, ref) => {
-    const [toDisplay, setToDisplay] = useState<DisplayResult>({
-      status: "OK",
-      svgDataUri: "",
+  ({ document, style, className, onResult, loadingComponent }, ref) => {
+    const [toDisplay, setToDisplay] = useState<DisplayResult | LoadingDisplayResult>({
+      status: "LOADING",
     });
 
     const renderMethod = document.renderMethod?.find((method) => method.type === SVG_RENDERER_TYPE);
@@ -183,6 +183,8 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
     };
 
     switch (toDisplay.status) {
+      case "LOADING":
+        return loadingComponent ? <>{loadingComponent}</> : null;
       case "DEFAULT":
         return <NoTemplate document={document} handleObfuscation={() => null} />;
       case "MALFORMED_SVG_ERROR":

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -82,6 +82,12 @@ const fetchSvg = async (svgInDoc: string, abortController: AbortController) => {
   return res;
 };
 
+const renderSvg = (template: string, document: any) => {
+  if (template.length === 0) return "";
+  const compiledTemplate = handlebars.compile(template);
+  return document.credentialSubject ? compiledTemplate(document.credentialSubject) : compiledTemplate(document);
+};
+
 // As specified in - https://w3c-ccg.github.io/vc-render-method/#svgrenderingtemplate2023
 export const SVG_RENDERER_TYPE = "SvgRenderingTemplate2023";
 
@@ -114,7 +120,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
       const handleValidSvgTemplate = (rawSvgTemplate: string) => {
         setToDisplay({
           status: "OK",
-          svgDataUri: `data:image/svg+xml,${encodeURIComponent(renderTemplate(rawSvgTemplate, document))}`,
+          svgDataUri: `data:image/svg+xml,${encodeURIComponent(renderSvg(rawSvgTemplate, document))}`,
         });
       };
 
@@ -169,12 +175,6 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
       };
       /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, [document]);
-
-    const renderTemplate = (template: string, document: any) => {
-      if (template.length === 0) return "";
-      const compiledTemplate = handlebars.compile(template);
-      return document.credentialSubject ? compiledTemplate(document.credentialSubject) : compiledTemplate(document);
-    };
 
     switch (toDisplay.status) {
       case "DEFAULT":

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -185,8 +185,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
     switch (toDisplay.status) {
       case "LOADING":
         return loadingComponent ? <>{loadingComponent}</> : null;
-      case "DEFAULT":
-        return <NoTemplate document={document} handleObfuscation={() => null} />;
+
       case "MALFORMED_SVG_ERROR":
         return (
           <DefaultTemplate
@@ -214,7 +213,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
           />
         );
       default:
-        return <></>;
+        return <NoTemplate document={document} handleObfuscation={() => null} />;
     }
   }
 );

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -173,8 +173,7 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
       return () => {
         abortController.abort();
       };
-      /* eslint-disable-next-line react-hooks/exhaustive-deps */
-    }, [document]);
+    }, [document, onResult, isSvgUrl, renderMethod, svgInDoc]);
 
     switch (toDisplay.status) {
       case "DEFAULT":

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -107,6 +107,8 @@ const SvgRenderer = React.forwardRef<HTMLImageElement, SvgRendererProps>(
     const isSvgUrl = urlPattern.test(svgInDoc);
 
     useEffect(() => {
+      setToDisplay({ status: "LOADING" });
+
       /** for what ever reason, the SVG template is missing or invalid */
       const handleInvalidSvgTemplate = (result: InvalidSvgTemplateDisplayResult) => {
         setToDisplay(result);

--- a/src/components/renderer/SvgRenderer.tsx
+++ b/src/components/renderer/SvgRenderer.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, useEffect, useState } from "react";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import bs58 from "bs58";
 import { ConnectionFailureTemplate, DefaultTemplate, NoTemplate, TamperedSvgTemplate } from "../../DefaultTemplate";
-import { v2 } from "@govtechsg/open-attestation";
+import type { v2 } from "@govtechsg/open-attestation";
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const handlebars = require("handlebars");
 

--- a/src/components/renderer/SvgV2Adapter.tsx
+++ b/src/components/renderer/SvgV2Adapter.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { SvgRenderer, SvgRendererProps, v4OpenAttestationDocument } from "./SvgRenderer";
-import { v2 } from "@govtechsg/open-attestation";
+import type { v2 } from "@govtechsg/open-attestation";
 
 const mapV2toV4 = (document: v2.OpenAttestationDocument): v4OpenAttestationDocument => {
   const clonedDocument = { ...document };
@@ -12,7 +12,9 @@ const mapV2toV4 = (document: v2.OpenAttestationDocument): v4OpenAttestationDocum
       id: document.issuers[0].id || "issuers[0].id not found",
       identityProof: {
         identifier: document.issuers[0].identityProof?.location || "issuers[0].identityProof.location not found",
-        identityProofType: document.issuers[0].identityProof?.type || v2.IdentityProofType.DNSDid,
+        identityProofType:
+          document.issuers[0].identityProof?.type ||
+          ("DNS-DID" as v4OpenAttestationDocument["issuer"]["identityProof"]["identityProofType"]),
       },
       name: document.issuers[0].name,
       type: "OpenAttestationIssuer",

--- a/src/components/renderer/SvgV2Adapter.tsx
+++ b/src/components/renderer/SvgV2Adapter.tsx
@@ -2,10 +2,20 @@ import React from "react";
 import { SvgRenderer, SvgRendererProps, v4OpenAttestationDocument } from "./SvgRenderer";
 import type { v2 } from "@govtechsg/open-attestation";
 
-const mapV2toV4 = (document: v2.OpenAttestationDocument): v4OpenAttestationDocument => {
+type V2OpenAttestationDocumentWithSvgBase = v2.OpenAttestationDocument &
+  Pick<SvgRendererProps["document"], "renderMethod">;
+type V2OpenAttestationDocumentWithSvg = V2OpenAttestationDocumentWithSvgBase & { [k: string]: unknown };
+
+const mapV2toV4 = (document: V2OpenAttestationDocumentWithSvg): v4OpenAttestationDocument => {
   const clonedDocument = { ...document };
-  const propsToOmit = ["$template", "id", "issuers", "network", "renderMethod"];
-  propsToOmit.forEach((v2Property) => delete (clonedDocument as any)[v2Property]);
+  const propsToOmit: (keyof V2OpenAttestationDocumentWithSvgBase)[] = [
+    "$template",
+    "id",
+    "issuers",
+    "network",
+    "renderMethod",
+  ];
+  propsToOmit.forEach((v2Property) => delete clonedDocument[v2Property]);
 
   return {
     issuer: {
@@ -19,14 +29,14 @@ const mapV2toV4 = (document: v2.OpenAttestationDocument): v4OpenAttestationDocum
       name: document.issuers[0].name,
       type: "OpenAttestationIssuer",
     },
-    renderMethod: (document as any)["renderMethod"],
+    renderMethod: document.renderMethod,
     credentialSubject: clonedDocument,
   };
 };
 
 export type __unsafe__not__for__production__v2__SvgRendererProps = Omit<SvgRendererProps, "document"> & {
   /** The OpenAttestation v2 document to display */
-  document: v2.OpenAttestationDocument;
+  document: V2OpenAttestationDocumentWithSvg;
 };
 
 const __unsafe__not__for__production__v2__SvgRenderer = React.forwardRef<

--- a/src/components/renderer/SvgV2Adapter.tsx
+++ b/src/components/renderer/SvgV2Adapter.tsx
@@ -1,5 +1,5 @@
-import React, { CSSProperties } from "react";
-import { DisplayResult, SvgRenderer, v4OpenAttestationDocument } from "./SvgRenderer";
+import React from "react";
+import { SvgRenderer, SvgRendererProps, v4OpenAttestationDocument } from "./SvgRenderer";
 import { v2 } from "@govtechsg/open-attestation";
 
 const mapV2toV4 = (document: v2.OpenAttestationDocument): v4OpenAttestationDocument => {
@@ -22,24 +22,17 @@ const mapV2toV4 = (document: v2.OpenAttestationDocument): v4OpenAttestationDocum
   };
 };
 
-export interface __unsafe__not__for__production__v2__SvgRendererProps {
-  /** The OpenAttestation v4 document to display */
-  document: v2.OpenAttestationDocument; // TODO: Update to OpenAttestationDocument
-  /** Override the img style */
-  style?: CSSProperties;
-  /** Override the img className */
-  className?: string;
-  // TODO: How to handle if svg fails at img? Currently it will return twice
-  /** An optional callback method that returns the display result  */
-  onResult?: (result: DisplayResult) => void;
-}
+export type __unsafe__not__for__production__v2__SvgRendererProps = Omit<SvgRendererProps, "document"> & {
+  /** The OpenAttestation v2 document to display */
+  document: v2.OpenAttestationDocument;
+};
 
 const __unsafe__not__for__production__v2__SvgRenderer = React.forwardRef<
   HTMLImageElement,
   __unsafe__not__for__production__v2__SvgRendererProps
->(({ document, style, className, onResult }, ref) => {
+>(({ document, ...rest }, ref) => {
   const remappedDocument = mapV2toV4(document);
-  return <SvgRenderer document={remappedDocument} style={style} className={className} onResult={onResult} ref={ref} />;
+  return <SvgRenderer {...rest} document={remappedDocument} ref={ref} />;
 });
 
 __unsafe__not__for__production__v2__SvgRenderer.displayName = "SvgRendererAdapterComponent";

--- a/src/components/renderer/fixtures/svgRendererSamples.ts
+++ b/src/components/renderer/fixtures/svgRendererSamples.ts
@@ -165,6 +165,34 @@ export const v4WithOnlyTamperedEmbeddedSvg = {
   },
 };
 
+export const v4MalformedEmbeddedSvg = {
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://schemata.openattestation.com/com/openattestation/4.0/alpha-context.json",
+  ],
+  issuer: {
+    id: "did:ethr:0xB26B4941941C51a4885E5B7D3A1B861E54405f90",
+    type: "OpenAttestationIssuer",
+    name: "Government Technology Agency of Singapore (GovTech)",
+    // identityProof: { identityProofType: v4.IdentityProofType.DNSDid, identifier: "example.openattestation.com" },
+    identityProof: { identityProofType: v2.IdentityProofType.DNSDid, identifier: "example.openattestation.com" },
+  },
+  // credentialStatus: { type: "OpenAttestationCredentialStatus", credentialStatusType: v4.CredentialStatusType.None },
+  credentialStatus: { type: "OpenAttestationCredentialStatus", credentialStatusType: "NONE" },
+  renderMethod: [
+    {
+      id: "",
+      type: "SvgRenderingTemplate2023",
+    },
+  ],
+  credentialSubject: {
+    id: "urn:uuid:a013fb9d-bb03-4056-b696-05575eceaf42",
+    type: ["SvgExample"],
+    course: { name: "SVG Basics Workshop", fromDate: "01/01/2024", endDate: "16/01/2024" },
+    recipient: { name: "TAN CHEN CHEN" },
+  },
+};
+
 export const v2WithSvgUrlAndDigestMultibase = {
   issuers: [
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from "react";
-import { v2, WrappedDocument, OpenAttestationDocument, v3 } from "@govtechsg/open-attestation";
+import type { v2, WrappedDocument, OpenAttestationDocument, v3 } from "@govtechsg/open-attestation";
 import { v4OpenAttestationDocument } from "./components/renderer/SvgRenderer";
 
 export type Attachment = v2.Attachment | v3.Attachment;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,10 +15,6 @@ module.exports = {
   },
   resolve: {
     extensions: [".js", ".jsx", ".ts", ".tsx"],
-    fallback: {
-      crypto: require.resolve("crypto-browserify"),
-      stream: require.resolve("stream-browserify"),
-    },
   },
   module: {
     rules: [


### PR DESCRIPTION
## What
1. use discriminated unions for `displayResult`
2. added loading state and option for users' own component
3. Use type import to prevent importing of `crypto` stuff again, reducing build size from 2mb to 600kb
4. bunch of refactors (see commits)

make sure we handle these scenarios
<img width="1584" alt="Screenshot 2024-04-23 at 12 43 01 AM" src="https://github.com/Open-Attestation/decentralized-renderer-react-components/assets/9160583/089c056b-895f-4d05-82a9-d5a2b0d12577">
